### PR TITLE
update downloadUrl depending env

### DIFF
--- a/app/src/components/projects-hub/script.js
+++ b/app/src/components/projects-hub/script.js
@@ -38,6 +38,10 @@ export default
             {
                 return ''
             }
+            
+            if (process.env.NODE_ENV === "production") {
+                return `/${this.currentProject.slug}/download`;
+            }
 
             return `${this.$store.state.serverConfig.domain}/${this.currentProject.slug}/download`
         }


### PR DESCRIPTION
Hello,

I work as a web developer teacher, and I normally use Keppler with my students at school on the same network.

But facing the Covid 19 situation, we can't be all together in the same place, so we don't share the same network anymore.

That's why, to keep using Keppler in this situation, I use [ngrok](https://ngrok.com/) to share my Keppler instance online with them.

But there is a bug in that case: "Download the whole project" feature doesn't work because the url is the local one, and not the one given by ngrok.

My pull request fixes this issue.

Thank you for this cool project!

