### PR TITLE
Keppler configuration file support

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -47,7 +47,7 @@ class App
      */
     setConfig()
     {
-        const config = {}
+        let config = {}
 
         // From arguments
         const args = require('yargs')
@@ -123,6 +123,12 @@ class App
                 default: '',
                 type: 'string'
             })
+            .option('config', {
+                alias: 'c',
+                describe: 'JSON Config file',
+                default: '.kepplerrc',
+                type: 'string'
+            })
             .argv
 
         config.debug = args.debug
@@ -135,6 +141,13 @@ class App
         config.maxFileSize = args['max-file-size']
         config.server = args.server
         config.host = args.host
+
+        try {
+            const strFile = fs.readFileSync(args.config, 'utf8')
+          
+            config = { ...config, ...JSON.parse(strFile) }
+            console.log(`${chalk.green.bold('app > config')} - ${chalk.cyan('configuration file found and loaded')}`)
+        } catch{}
 
         if(config.limit === -1)
         {

--- a/lib/index.js
+++ b/lib/index.js
@@ -147,7 +147,7 @@ class App
           
             config = { ...config, ...JSON.parse(strFile) }
             console.log(`${chalk.green.bold('app > config')} - ${chalk.cyan('configuration file found and loaded')}`)
-        } catch{}
+        } catch {}
 
         if(config.limit === -1)
         {

--- a/readme.md
+++ b/readme.md
@@ -138,8 +138,8 @@ Arguments list
 
 |||
 |---|---|
-|parameter|`--host`|
-|shortcut|`-h`|
+|parameter|`--config`|
+|shortcut|`-c`|
 |default value|*(string)*`.kepplerrc`|
 |description|Configuration file<br>(as JSON, with parameters as keys)|
 

--- a/readme.md
+++ b/readme.md
@@ -136,6 +136,13 @@ Arguments list
 |default value|*(number)*`1571`|
 |description|Server port|
 
+|||
+|---|---|
+|parameter|`--host`|
+|shortcut|`-h`|
+|default value|*(string)*`.kepplerrc`|
+|description|Configuration file<br>(as JSON, with parameters as keys)|
+
 ## Online instance
 
 You can run Keppler online. Anyone with access to the server will be able to see the projects without having to be on the same network as you.


### PR DESCRIPTION
Use of a json config file instead of command line parameters as asked in #66 

## Features & Behavior

Added `--config` param for specifying the JSON config file path.

As the config param is defaulted to `.kepplerrc` it silently try to read a config file, if found: read the configuration. 

Configuration file should be a JSON with key-values following documented parameters rules. e.g:

```json
{
  "name": "My project",
  "host": "localhost",
  "port": "8080",
  "open": true,
  "debug": 1
}
```
